### PR TITLE
code to subset just the DAS and AA fleets

### DIFF
--- a/analysis_code/scallop_analysis_0322.Rmd
+++ b/analysis_code/scallop_analysis_0322.Rmd
@@ -352,7 +352,7 @@ scallop0322MainDataTable <-
   fleet_assign(scallop0322MainDataTable, project = project, 
                fleet_tab = fleet_tab_name)
 ```
-
+By setting this code chunk to include=TRUE, all of the statistics from this point forward are just for the Limited Access Fleet, which takes Access Area and Days-at-Sea trips. 
 ```{r retain_AA_DAS, include=TRUE}
 
 scallop0322MainDataTable <- 


### PR DESCRIPTION
1. I can't test the code, so I set include=FALSE
2. My tidy is really terrible, so I'm not positive this actually is the correct syntax to filter the DAS and AA fleets.
3. I'm not sure what happens when you modify a sql-lite table

There are two downstream things that might break:

Line 455: Not sure what this does:
```
count(fleet, in_closure, LA, GC, .drop = FALSE) %>% 
```

Line 663   
```
filter(fleet == "General Cat") %>% 
```

This will return an empty data.frame.  Not sure if this is bad.  If it just prints an empty table, that's not so bad.
