### PR TITLE
Adjusting both spatial joins

### DIFF
--- a/data_wrangle/data_processing.Rmd
+++ b/data_wrangle/data_processing.Rmd
@@ -714,6 +714,4 @@ LA_Estimate <- VTR_DMIS_AC_Agg %>% filter(Agg_LANDED >= 850 & CREW <= 8)
 ```
 
 
-# to read this in, you will want to do the here::i_am dance and then read in
-# final_product_savename <-paste0("final_product_lease_",vintage_string,".Rds")
-# final_product_lease <-readRDS(here("data","main",final_product_savename))
+


### PR DESCRIPTION
Added back in the pre-fishset spatial join so both are included; this adds to new variables to the data processing rmd, ZoneID and lease_FS. ZoneID will reflect what zone an observation will be binned into after the spatial join. lease_FS contains the name of the wind lease area an observation takes place in using the same join method. I also changed the vintage string in the processing Rmd to match the extracting Rmd to create the newest data set in FishSET 