### PR TITLE
Mle2718 patch 1 1

### DIFF
--- a/analysis_code/scallop_analysis_0322.Rmd
+++ b/analysis_code/scallop_analysis_0322.Rmd
@@ -194,10 +194,10 @@ summary_stats(scallop0322MainDataTable, project) %>%
   pretty_tab_sb()
 ```
 
-Here is DOLLAR, MEAT_POUNDS, and TRIP_LENGTH separately. 
+Here is DOLLAR, POUNDS, and TRIP_LENGTH separately. 
 ```{r}
 scallop0322MainDataTable %>% 
-  summarize(across(.cols = c("DOLLAR", "MEAT_POUNDS", "TRIP_LENGTH"), 
+  summarize(across(.cols = c("DOLLAR", "POUNDS", "TRIP_LENGTH"), 
                    .fns = list(min = min, median = median, mean = mean, max = max, 
                                NAs = ~sum(is.na(.x)), UniqueObs = n_distinct, 
                                "No. 0's" = ~sum(.x == 0)), 


### PR DESCRIPTION
The “pounds” field is in live pounds. 8.33 live pounds==1 pound of meats. We should use meat weights, because everyone thinks in meat pounds and the regulations are in meat weights.

- Renamed "pounds" to "LIVE_POUNDS" for clarity. 
- created "MEAT_POUNDS" and subsequent analysis to meats.