### PR TITLE
sort and pick the first row.

### DIFF
--- a/analysis_code/scallop_analysis_0322.Rmd
+++ b/analysis_code/scallop_analysis_0322.Rmd
@@ -269,7 +269,8 @@ scallop0322MainDataTable <-
   scallop0322MainDataTable %>%
   group_by(TRIPID) %>%
   mutate(Agg_DOLLAR = sum(DOLLAR),Agg_DOLLAR_2020 = sum(DOLLAR_2020),  Agg_POUNDS = sum(POUNDS), Agg_LANDED = sum(LANDED), Agg_DOLLAR_ALL_SP_2020 = sum(DOLLAR_ALL_SP_2020))%>% 
-  filter(DOLLAR == max(DOLLAR)) %>% 
+  arrange(desc(DOLLAR)) %>%
+  dplyr::filter(row_number()==1) %>% 
   dplyr::select(-DOLLAR, -POUNDS, -LANDED,-DOLLAR_ALL_SP_2020, -DOLLAR_2020) %>% 
   rename(DOLLAR = "Agg_DOLLAR", POUNDS = "Agg_POUNDS", LANDED = "Agg_LANDED", DOLLAR_ALL_SP_2020 = "Agg_DOLLAR_ALL_SP_2020", DOLLAR_2020="Agg_DOLLAR_2020") %>% 
   ungroup()


### PR DESCRIPTION
If two (or more) subtrips have the highest value of DOLLAR, this will pick both subtrips and there will be duplicate TRIPIDS.

This happened 1 time, with a GC or IFQ vessel.

The new way just picks one by sorting and then taking the first row. I don't know which one is chosen, and I don't much care.