### PR TITLE
relocate where we compute areas

### DIFF
--- a/data_wrangle/combine_cable_routes.Rmd
+++ b/data_wrangle/combine_cable_routes.Rmd
@@ -367,6 +367,12 @@ wind_Central_Atlantic_1$area_ms2 <- sf::st_area(wind_Central_Atlantic_1)
   
 wind_Central_Atlantic_2$area_ms2 <- sf::st_area(wind_Central_Atlantic_2)
 
+#We don't use CA2,but i'm putting this in here to match the others, just in case
+wind_Central_Atlantic_2 <- wind_Central_Atlantic_2 %>% 
+                                          mutate(area_ms2_sum = sum(area_ms2))
+
+
+
 wind_Central_Atlantic_3$area_ms2 <- sf::st_area(wind_Central_Atlantic_3)
    wind_Central_Atlantic_3 <- wind_Central_Atlantic_3 %>% 
                                           mutate(area_ms2_sum = sum(area_ms2))


### PR DESCRIPTION
@Ardini-NOAA -- i think this fixes some of our problems. I'm going to put it right into main

We were reducing the shapefiles to just 1 object to compute areas AND THEN saving it. This is obviously no bueno. We will relocated the code that does these manipulations to after the saving.


To verify this works, we need to 
1. Restart R and pull main 
2. knit the "combine_cable_routes.Rmd" to html
3. knit the scallop_analysis_tiny_report.Rmd (don't change any options in the the doc).  This tests out Cent Atlantic 3 and shoudl run
4. Restart R. Run the knit_tiny_scallop_analysis_loop.R to create all our datasets.
5. knit the case_study_comparisions.Rmd