### PR TITLE
Ml patch z

### DIFF
--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -232,9 +232,9 @@ dropped_values_CA_1_3_DAS <- dropped_values_CA_1_3_LA %>% filter(fleet == "Days 
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 
-Inside_CA2_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+# Inside_CA2_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 Inside_CA3_LA %>%
   group_by(fleet) %>%
@@ -262,10 +262,10 @@ Inside_CA1_LA %>%
                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win))
 
 
-Inside_CA2_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win))
+# Inside_CA2_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win))
 
 
 Inside_CA3_LA %>%
@@ -303,9 +303,9 @@ Inside_CA1_GC %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 
-Inside_CA2_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 Inside_CA3_GC %>%
   group_by(fleet) %>%
@@ -332,10 +332,10 @@ Inside_CA1_GC %>%
                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
-Inside_CA2_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
 Inside_CA3_GC %>%

--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -279,16 +279,16 @@ dropped_values_CA_1_3_LA %>%
                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
-dropped_values_CA_1_2_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
-
-
-dropped_values_CA_2_3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+# dropped_values_CA_1_2_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+# 
+# 
+# dropped_values_CA_2_3_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
 ```
@@ -351,16 +351,16 @@ dropped_values_CA_1_3_GC %>%
                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
-dropped_values_CA_1_2_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
-
-
-dropped_values_CA_2_3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+# dropped_values_CA_1_2_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+# 
+# 
+# dropped_values_CA_2_3_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
 
 
 ```

--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -173,14 +173,14 @@ view_lon_lat(Inside_CA3_LA, lon = "DDLON", lat ="DDLAT")
 ## New York Bight
 
 
- Inside_NY1_AA <- Inside_CA1_LA %>% filter(fleet == "Access Area") 
- Inside_CA1_DAS <- Inside_CA1_LA %>% filter(fleet == "Days at Sea") 
+ Inside_NY1_AA <- Inside_NY1_LA %>% filter(fleet == "Access Area") 
+ Inside_NY1_DAS <- Inside_NY1_LA %>% filter(fleet == "Days at Sea") 
  
- Inside_NY2_AA <- Inside_CA2_LA %>% filter(fleet == "Access Area") 
- Inside_NY2_DAS <- Inside_CA2_LA %>% filter(fleet == "Days at Sea") 
+ Inside_NY2_AA <- Inside_NY2_LA %>% filter(fleet == "Access Area") 
+ Inside_NY2_DAS <- Inside_NY2_LA %>% filter(fleet == "Days at Sea") 
  
- Inside_NY3_AA <- Inside_CA3_LA %>% filter(fleet == "Access Area") 
- Inside_NY3_DAS <- Inside_CA3_LA %>% filter(fleet == "Days at Sea") 
+ Inside_NY3_AA <- Inside_NY3_LA %>% filter(fleet == "Access Area") 
+ Inside_NY3_DAS <- Inside_NY3_LA %>% filter(fleet == "Days at Sea") 
  
  
  dropped_values_NY_1_2_AA <- dropped_values_NY_1_2_LA %>% filter(fleet == "Access Area") 
@@ -190,9 +190,6 @@ view_lon_lat(Inside_CA3_LA, lon = "DDLON", lat ="DDLAT")
  dropped_values_NY_2_3_DAS <- dropped_values_NY_2_3_LA %>% filter(fleet == "Days at Sea") 
 
  
- dropped_values_NY_1_3_AA <- dropped_values_NY_1_2_LA %>% filter(fleet == "Access Area") 
- dropped_values_NY_1_3_DAS <- dropped_values_NY_1_2_LA %>% filter(fleet == "Days at Sea") 
-
 
 
 ## Central Atlantic
@@ -234,25 +231,22 @@ Total revenue and operating profits
 
 
 
- Inside_NY2_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
- Inside_NY3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-
-
  dropped_values_NY_1_2_GC %>%
   group_by(fleet) %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
- dropped_values_NY_2_3_GC %>%
+ Inside_NY2_GC %>%
   group_by(fleet) %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
+ 
+ dropped_values_NY_2_3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+ 
+ Inside_NY3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 ```
 
@@ -266,26 +260,126 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 
  Inside_NY1_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win)  )
-
- Inside_NY2_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win)  )
-
- Inside_NY3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win)  )
-
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
  dropped_values_NY_1_2_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win)  )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+ Inside_NY2_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
  dropped_values_NY_2_3_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(), DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win)  )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+  Inside_NY3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+
 ```
+
+
+
+## NY GC-IFQ z-tests
+
+Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
+
+
+```{r, NYB_GC_tests}
+## Phase 1 
+## REVENUE
+
+BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
+  y = Inside_NY2_GC$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_NY_1_2_GC$DOLLAR_2022_win),
+  sigma.y = sd(Inside_NY2_GC$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Landed
+
+BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
+  y = Inside_NY2_GC$LANDED_win,
+  sigma.x = sd(dropped_values_NY_1_2_GC$LANDED_win),
+  sigma.y = sd(Inside_NY2_GC$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Operating Profit
+
+BSDA::z.test(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win,
+  y = Inside_NY2_GC$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_NY2_GC$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE
+
+BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
+  y = Inside_NY2_GC$VPUE_win,
+  sigma.x = sd(dropped_values_NY_1_2_GC$VPUE_win),
+  sigma.y = sd(Inside_NY2_GC$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+## Phase 2 REVENUE
+
+BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
+  y = Inside_NY3_GC$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_GC$DOLLAR_2022_win),
+  sigma.y = sd(Inside_NY3_GC$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Landed
+BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
+  y = Inside_NY3_GC$LANDED_win,
+  sigma.x = sd(dropped_values_NY_2_3_GC$LANDED_win),
+  sigma.y = sd(Inside_NY3_GC$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+
+## Operating Profit
+BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
+  y = Inside_NY3_GC$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_NY3_GC$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE
+BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
+  y = Inside_NY3_GC$VPUE_win,
+  sigma.x = sd(dropped_values_NY_2_3_GC$VPUE_win),
+  sigma.y = sd(Inside_NY3_GC$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+```
+
+
+
+
+
+
+
+
 
 
 
@@ -298,27 +392,23 @@ Total revenue and operating profits
   group_by(fleet) %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
+ dropped_values_NY_1_2_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 
  Inside_NY2_LA %>%
   group_by(fleet) %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
- Inside_NY3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-
-
- dropped_values_NY_1_2_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
  dropped_values_NY_2_3_LA %>%
   group_by(fleet) %>%
   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
+ Inside_NY3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 ```
 
@@ -333,31 +423,30 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 
  Inside_NY1_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win))
-
-
-
- Inside_NY2_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win))
-
- Inside_NY3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win))
-
-
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
  dropped_values_NY_1_2_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win))
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
-
- dropped_values_NY_2_3_LA %>%
+ Inside_NY2_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), LANDED_win=mean(LANDED_win),VPUE_win=mean(VPUE_win))
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
+  dropped_values_NY_2_3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+ 
+ Inside_NY3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win),
+                  OPERATING_PROFIT_2022_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 
@@ -365,62 +454,19 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 ```
 
 
-## NY GC-IFQ Revenue Z-Tests 
 
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
+## NY Limited Access z-tests
 
-```{r, NY_GC_Revenue_tests}
-## Phase 1
-
-BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
-  y = Inside_NY2_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2
-
-BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
-  y = Inside_NY3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
+Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
 
 
-
-```
-
-
-## NY Limited Access Revenue z-tests
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
-
-
-```{r, NY_LA_Revenue_tests}
-
-# Access Area 
-## Phase 1 to 2
-BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$DOLLAR_2022_win,
-  y = Inside_NY3_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
+```{r, NY_DAS_tests}
 
 
 # Days-at-Sea
-## Phase 1 to 2
+## Phase 1 
 
+## REVENUE
 BSDA::z.test(dropped_values_NY_1_2_DAS$DOLLAR_2022_win,
   y = Inside_NY2_DAS$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$DOLLAR_2022_win),
@@ -428,76 +474,7 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$DOLLAR_2022_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_NY3_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-```
-
-
-
-
-## NY GC-IFQ Landed z-tests
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
-
-
-```{r, NY_GC_Landed_tests}
-## Phase 1
-
-BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
-  y = Inside_NY2_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$LANDED_win),
-  sigma.y = sd(Inside_NY2_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 2
-BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
-  y = Inside_NY3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$LANDED_win),
-  sigma.y = sd(Inside_NY3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-```
-
-
-
-## NY Limited Access Landed z-tests
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
-
-
-```{r, NY_LA_Landed_tests}
-
-# Access Area 
-## Phase 1 to 2
-BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$LANDED_win,
-  y = Inside_NY3_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-# Days-at-Sea
-## Phase 1 to 2
-
+## Landed
 BSDA::z.test(dropped_values_NY_1_2_DAS$LANDED_win,
   y = Inside_NY2_DAS$LANDED_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$LANDED_win),
@@ -505,79 +482,8 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$LANDED_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
+## Operating Profit
 
-## Phase 2 to 3
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$LANDED_win,
-  y = Inside_NY3_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_NY2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-```
-
-
-
-
-
-
-## NY GCIFQ Operating Profit Z-Tests 
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
-
-
-
-```{r, NY_GC_Operating_profit_tests}
-# Phase 1 to 2 
-
-BSDA::z.test(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-# Phase 2 to 3 
-
-BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-```
-
-## NY Limited Access Operating Profit z-tests 
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
-
-```{r, NY_LA_Operating_profit_tests}
-
-# Access Area 
-## Phase 1 to 2
-BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY3_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-# Days-at-Sea
-## Phase 1 to 2
 BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
   y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win),
@@ -585,96 +491,8 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
+## VPUE
 
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY3_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-```
-
-
-
-
-## NY GCIFQ VPUE Z-Tests 
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
-
-
-
-
-```{r, NY_GC_VPUE_tests}
-# Phase 1 to 2 
-BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
-  y = Inside_NY2_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$VPUE_win),
-  sigma.y = sd(Inside_NY2_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-# Phase 2 to 3 
-BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
-  y = Inside_NY3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$VPUE_win),
-  sigma.y = sd(Inside_NY3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-```
-
-
-
-## NY Limited Access VPUE z-tests
-
-Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
-
-
-```{r, NY_LA_VPUE_tests}
-# LA 
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_LA$VPUE_win,
-  y = Inside_NY2_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_LA$VPUE_win),
-  sigma.y = sd(Inside_NY2_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_LA$VPUE_win,
-  y = Inside_NY3_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_LA$VPUE_win),
-  sigma.y = sd(Inside_NY3_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-# Access Area 
-## Phase 1 to 2
-BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
-  y = Inside_NY2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_NY2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
-  y = Inside_NY3_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_NY3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-# Days-at-Sea
-## Phase 1 to 2
 BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
   y = Inside_NY2_DAS$VPUE_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$VPUE_win),
@@ -683,7 +501,35 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
   conf.level = 0.99)
 
 
-## Phase 2 to 3
+## Phase 2
+
+## REVENUE
+BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
+  y = Inside_NY3_DAS$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_DAS$DOLLAR_2022_win),
+  sigma.y = sd(Inside_NY3_DAS$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Landed
+BSDA::z.test(dropped_values_NY_2_3_DAS$LANDED_win,
+  y = Inside_NY3_DAS$LANDED_win,
+  sigma.x = sd(dropped_values_NY_2_3_DAS$LANDED_win),
+  sigma.y = sd(Inside_NY3_DAS$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Operating Profit
+
+BSDA::z.test(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win,
+  y = Inside_NY3_DAS$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_NY3_DAS$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE
+
 BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
   y = Inside_NY3_DAS$VPUE_win,
   sigma.x = sd(dropped_values_NY_2_3_DAS$VPUE_win),
@@ -692,11 +538,225 @@ BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
   conf.level = 0.99)
 
 
+```
+
+
+Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
+
+```{r, NY_AA_tests}
+# Access Area 
+## Phase 1 
+
+## REVENUE
+BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
+  y = Inside_NY2_AA$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_NY_1_2_AA$DOLLAR_2022_win),
+  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Landed
+BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
+  y = Inside_NY2_AA$LANDED_win,
+  sigma.x = sd(dropped_values_NY_1_2_AA$LANDED_win),
+  sigma.y = sd(Inside_NY2_AA$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Operating Profit
+
+BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
+  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_NY2_AA$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE
+
+BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
+  y = Inside_NY2_AA$VPUE_win,
+  sigma.x = sd(dropped_values_NY_1_2_AA$VPUE_win),
+  sigma.y = sd(Inside_NY2_AA$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+## Phase 2
+
+## REVENUE
+BSDA::z.test(dropped_values_NY_2_3_AA$DOLLAR_2022_win,
+  y = Inside_NY3_AA$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_AA$DOLLAR_2022_win),
+  sigma.y = sd(Inside_NY3_AA$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Landed
+BSDA::z.test(dropped_values_NY_2_3_AA$LANDED_win,
+  y = Inside_NY3_AA$LANDED_win,
+  sigma.x = sd(dropped_values_NY_2_3_AA$LANDED_win),
+  sigma.y = sd(Inside_NY3_AA$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Operating Profit
+
+BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
+  y = Inside_NY3_AA$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_NY3_AA$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE
+
+BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
+  y = Inside_NY3_AA$VPUE_win,
+  sigma.x = sd(dropped_values_NY_2_3_AA$VPUE_win),
+  sigma.y = sd(Inside_NY3_AA$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+
+
+
+
+
+
 
 ```
 
 
 # Central Atlantic Section 
+
+
+
+## Aggregate Scallop revenue CA1, CA2, and CA3 and the Dropped Values from 1-3 for the GCIFQ Fleet
+
+```{r}
+
+
+Inside_CA1_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+Inside_CA3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+
+dropped_values_CA_1_3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+```
+
+## Average Winsorized Revenue, VPUE, Operating Profit, and Landed weights for the Central Atlantic, GCIFQ
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r}
+
+Inside_CA1_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+Inside_CA3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+
+dropped_values_CA_1_3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+# dropped_values_CA_1_2_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+# 
+# 
+# dropped_values_CA_2_3_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+```
+
+
+
+## CA GC-IFQ Z-Tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+The first command tests the equality Winsorized Dollars for the Trips that were dropped during the CA 1 to CA 3 process (Call area to Lease Area)  against the trips that remained inside at the CA3 step (Lease Areas).  Other commands are defined analgously.
+
+```{r, CA1_to_3GC_tests}
+
+BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
+  y = Inside_CA3_GC$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
+  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
+  y = Inside_CA3_GC$LANDED_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
+  sigma.y = sd(Inside_CA3_GC$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
+  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
+  y = Inside_CA3_GC$VPUE_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
+  sigma.y = sd(Inside_CA3_GC$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+```
+
+
+
+
+
+
+
 
 
 ## Aggregate Scallop Revenue and Operating Profit CA1, CA2, and CA3 and the Dropped Values from 1-3 for the LA Fleet
@@ -768,106 +828,20 @@ dropped_values_CA_1_3_LA %>%
 
 ```
 
-## Aggregate Scallop revenue CA1, CA2, and CA3 and the Dropped Values from 1-3 for the GCIFQ Fleet
-
-```{r}
-
-
-Inside_CA1_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-# Inside_CA2_GC %>%
-#   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-Inside_CA3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
 
 
 
-dropped_values_CA_1_3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+## CA Limited Access Access Area Z-Tests
 
-```
+Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
-##Average Winsorized Revenue, VPUE, Operating Profit, and Landed weights for the Central Atlantic, GCIFQ
+```{r, CA1_to_3AA_tests}
 
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r}
-
-Inside_CA1_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-# Inside_CA2_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-Inside_CA3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-
-dropped_values_CA_1_3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-# dropped_values_CA_1_2_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-# 
-# 
-# dropped_values_CA_2_3_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-```
-
-
-## CA GC-IFQ Revenue Z-Tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-The first command tests the equality Winsorized Dollars for the Trips that were dropped during the CA 1 to CA 3 process (Call area to Lease Area)  against the trips that remained inside at the CA3 step (Lease Areas).  These are done at the 90, 95, and 99\% confidence levels.  Other commands are defined analgously.
-
-```{r, CA1_to_3GC_Dollar_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
-  y = Inside_CA3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-
-## CA Limited Access Revenue Z-Tests
-
-Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_Dollar_tests}
-
+# Access Area 
 ## Phase 1 to 3
+
+## Dollar
+
 
 BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
   y = Inside_CA3_AA$DOLLAR_2022_win,
@@ -876,45 +850,7 @@ BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA3_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-## CA GC-IFQ Landed z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-```{r, CA1_to_3GC_Landed_tests}
-
-
-BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
-  y = Inside_CA3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
-  sigma.y = sd(Inside_CA3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-```
-
-
-## CA Limited Access Landed z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_Landed_tests}
-
-## Phase 1 to 3
-
+## Landed 
 BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
   y = Inside_CA3_AA$LANDED_win,
   sigma.x = sd(dropped_values_CA_1_3_AA$LANDED_win),
@@ -922,99 +858,14 @@ BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
-
-
-# Days-at-Sea
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
-  y = Inside_CA3_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-```
-
-
-## CA GCIFQ Operating Profit z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3GC_OperatingProfit_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-```
-
-## CA Limited Access Operating Profit z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_OperatingProfit_tests}
-
-# Access Area 
-## Phase 1 to 3
-
+## Operating Profit 
 BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
   y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win),
   sigma.y = sd(Inside_CA3_AA$OPERATING_PROFIT_2022_win),
   alternative = c("two.sided"),
   conf.level = 0.99)
-
-
-
-# Days-at-Sea
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-
-```
-
-
-## CA GCIFQ z-tests VPUE
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3GC_VPUE_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
-  y = Inside_CA3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
-  sigma.y = sd(Inside_CA3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-## CA Limited Access z-tests VPUE
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_VPUE_tests}
-
-# Access Area 
-## Phase 1 to 3
+## VPUE 
 BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
   y = Inside_CA3_AA$VPUE_win,
   sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
@@ -1022,12 +873,43 @@ BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
+```
 
 
+
+Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+```{r, CA1_to_3DAS_tests}
 
 # Days-at-Sea
-
 ## Phase 1 to 3
+
+## Dollar
+
+
+BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
+  y = Inside_CA3_DAS$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
+  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+## Landed 
+BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
+  y = Inside_CA3_DAS$LANDED_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
+  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## Operating Profit 
+BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
+  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+## VPUE 
 BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
   y = Inside_CA3_DAS$VPUE_win,
   sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
@@ -1035,10 +917,8 @@ BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
   alternative = c("two.sided"),
   conf.level = 0.99)
 
-
-
-
-
 ```
+
+
 
 

--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -258,31 +258,31 @@ dropped_values_CA_1_3_LA %>%
 ```{r}
 Inside_CA1_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win))
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
 
 
 # Inside_CA2_LA %>%
 #   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win))
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
 
 
 Inside_CA3_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
 
 dropped_values_CA_1_3_LA %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
 
 
 # dropped_values_CA_1_2_LA %>%
 #   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
 # 
 # 
 # dropped_values_CA_2_3_LA %>%
@@ -328,39 +328,39 @@ dropped_values_CA_1_3_GC %>%
 
 Inside_CA1_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 # Inside_CA2_GC %>%
 #   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 Inside_CA3_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 
 dropped_values_CA_1_3_GC %>%
   group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-                   LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 # dropped_values_CA_1_2_GC %>%
 #   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 # 
 # 
 # dropped_values_CA_2_3_GC %>%
 #   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
 
 
 ```

--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -220,352 +220,6 @@ dropped_values_CA_1_3_DAS <- dropped_values_CA_1_3_LA %>% filter(fleet == "Days 
 
 
 ```
-
-# Central Atlantic Section 
-
-
-## Aggregate Scallop Revenue and Operating Profit CA1, CA2, and CA3 and the Dropped Values from 1-3 for the LA Fleet
-
-```{r}
- Inside_CA1_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-# Inside_CA2_LA %>%
-#   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-Inside_CA3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-
-dropped_values_CA_1_3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-```
-
-
-
-## Average Winsorized Revenue, VPUE, Operating Profit, and Landings in CA closures by fleet LA 
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r}
-Inside_CA1_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
-                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
-
-
-# Inside_CA2_LA %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
-#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
-
-
-Inside_CA3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
-                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
-
-dropped_values_CA_1_3_LA %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
-                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
-
-
-# dropped_values_CA_1_2_LA %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
-#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
-# 
-# 
-# dropped_values_CA_2_3_LA %>%
-#   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
-#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
-
-
-```
-
-## Aggregate Scallop revenue CA1, CA2, and CA3 and the Dropped Values from 1-3 for the GCIFQ Fleet
-
-```{r}
-
-
-Inside_CA1_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-# Inside_CA2_GC %>%
-#   group_by(fleet) %>%
-#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-Inside_CA3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-
-
-dropped_values_CA_1_3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
-
-```
-
-##Average Winsorized Revenue, VPUE, Operating Profit, and Landed weights for the Central Atlantic, GCIFQ
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r}
-
-Inside_CA1_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-# Inside_CA2_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-Inside_CA3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-
-dropped_values_CA_1_3_GC %>%
-  group_by(fleet) %>%
-  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-# dropped_values_CA_1_2_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-# 
-# 
-# dropped_values_CA_2_3_GC %>%
-#   group_by(fleet) %>%
-#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
-#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
-
-
-```
-
-
-## CA GC-IFQ Revenue Z-Tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-The first command tests the equality Winsorized Dollars for the Trips that were dropped during the CA 1 to CA 3 process (Call area to Lease Area)  against the trips that remained inside at the CA3 step (Lease Areas).  These are done at the 90, 95, and 99\% confidence levels.  Other commands are defined analgously.
-
-```{r, CA1_to_3GC_Dollar_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
-  y = Inside_CA3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-
-## CA Limited Access Revenue Z-Tests
-
-Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_Dollar_tests}
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
-  y = Inside_CA3_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA3_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-## CA GC-IFQ Landed z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-```{r, CA1_to_3GC_Landed_tests}
-
-
-BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
-  y = Inside_CA3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
-  sigma.y = sd(Inside_CA3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-```
-
-
-## CA Limited Access Landed z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_Landed_tests}
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
-  y = Inside_CA3_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA3_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-# Days-at-Sea
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
-  y = Inside_CA3_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-```
-
-
-## CA GCIFQ Operating Profit z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3GC_OperatingProfit_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-```
-
-## CA Limited Access Operating Profit z-tests
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_OperatingProfit_tests}
-
-# Access Area 
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-# Days-at-Sea
-
-## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-
-```
-
-
-## CA GCIFQ z-tests VPUE
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3GC_VPUE_tests}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
-  y = Inside_CA3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
-  sigma.y = sd(Inside_CA3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-```
-
-## CA Limited Access z-tests VPUE
-
- Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
-
-
-```{r, CA1_to_3AA_VPUE_tests}
-
-# Access Area 
-## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
-  y = Inside_CA3_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-
-# Days-at-Sea
-
-## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
-  y = Inside_CA3_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA3_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-
-
-
-```
-
 # New York Bight (NY) Comparisons
 
 
@@ -1036,6 +690,352 @@ BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
   sigma.y = sd(Inside_NY3_DAS$VPUE_win),
   alternative = c("two.sided"),
   conf.level = 0.99)
+
+
+
+```
+
+
+# Central Atlantic Section 
+
+
+## Aggregate Scallop Revenue and Operating Profit CA1, CA2, and CA3 and the Dropped Values from 1-3 for the LA Fleet
+
+```{r}
+ Inside_CA1_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+# Inside_CA2_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+Inside_CA3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+
+dropped_values_CA_1_3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+```
+
+
+
+## Average Winsorized Revenue, VPUE, Operating Profit, and Landings in CA closures by fleet LA 
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r}
+Inside_CA1_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
+
+
+# Inside_CA2_LA %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
+
+
+Inside_CA3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
+
+dropped_values_CA_1_3_LA %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
+
+
+# dropped_values_CA_1_2_LA %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win), LANDED_win=mean(LANDED_win),
+#                   OPERATING_win=mean(OPERATING_PROFIT_2022_win),VPUE_win=mean(VPUE_win) )
+# 
+# 
+# dropped_values_CA_2_3_LA %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),VPUE_win=mean(VPUE_win),
+#                    LANDED_win=mean(LANDED_win), OPERATING_win=mean(OPERATING_PROFIT_2022_win) )
+
+
+```
+
+## Aggregate Scallop revenue CA1, CA2, and CA3 and the Dropped Values from 1-3 for the GCIFQ Fleet
+
+```{r}
+
+
+Inside_CA1_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#   dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+Inside_CA3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+
+
+dropped_values_CA_1_3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=sum(DOLLAR_2022_win),OPERATING_PROFIT_2022_win=sum(OPERATING_PROFIT_2022_win), count_PERMITs=n_distinct(PERMIT.y))
+
+```
+
+##Average Winsorized Revenue, VPUE, Operating Profit, and Landed weights for the Central Atlantic, GCIFQ
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r}
+
+Inside_CA1_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+# Inside_CA2_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+Inside_CA3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+
+dropped_values_CA_1_3_GC %>%
+  group_by(fleet) %>%
+  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+# dropped_values_CA_1_2_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+# 
+# 
+# dropped_values_CA_2_3_GC %>%
+#   group_by(fleet) %>%
+#  dplyr::summarise(Trips=n(),DOLLAR_2022_win=mean(DOLLAR_2022_win),LANDED_win=mean(LANDED_win), 
+#                  OPERATING_win=mean(OPERATING_PROFIT_2022_win), VPUE_win=mean(VPUE_win)  )
+
+
+```
+
+
+## CA GC-IFQ Revenue Z-Tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+The first command tests the equality Winsorized Dollars for the Trips that were dropped during the CA 1 to CA 3 process (Call area to Lease Area)  against the trips that remained inside at the CA3 step (Lease Areas).  These are done at the 90, 95, and 99\% confidence levels.  Other commands are defined analgously.
+
+```{r, CA1_to_3GC_Dollar_tests}
+
+BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
+  y = Inside_CA3_GC$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
+  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+```
+
+
+## CA Limited Access Revenue Z-Tests
+
+Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3AA_Dollar_tests}
+
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
+  y = Inside_CA3_AA$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_AA$DOLLAR_2022_win),
+  sigma.y = sd(Inside_CA3_AA$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
+  y = Inside_CA3_DAS$DOLLAR_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
+  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+```
+
+## CA GC-IFQ Landed z-tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+```{r, CA1_to_3GC_Landed_tests}
+
+
+BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
+  y = Inside_CA3_GC$LANDED_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
+  sigma.y = sd(Inside_CA3_GC$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+```
+
+
+## CA Limited Access Landed z-tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3AA_Landed_tests}
+
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
+  y = Inside_CA3_AA$LANDED_win,
+  sigma.x = sd(dropped_values_CA_1_3_AA$LANDED_win),
+  sigma.y = sd(Inside_CA3_AA$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+# Days-at-Sea
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
+  y = Inside_CA3_DAS$LANDED_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
+  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+```
+
+
+## CA GCIFQ Operating Profit z-tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3GC_OperatingProfit_tests}
+
+BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
+  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+```
+
+## CA Limited Access Operating Profit z-tests
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3AA_OperatingProfit_tests}
+
+# Access Area 
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
+  y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_CA3_AA$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+# Days-at-Sea
+
+## Phase 1 to 3
+
+BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
+  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
+  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+
+```
+
+
+## CA GCIFQ z-tests VPUE
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3GC_VPUE_tests}
+
+BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
+  y = Inside_CA3_GC$VPUE_win,
+  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
+  sigma.y = sd(Inside_CA3_GC$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+```
+
+## CA Limited Access z-tests VPUE
+
+ Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
+
+
+```{r, CA1_to_3AA_VPUE_tests}
+
+# Access Area 
+## Phase 1 to 3
+BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
+  y = Inside_CA3_AA$VPUE_win,
+  sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
+  sigma.y = sd(Inside_CA3_AA$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
+
+
+# Days-at-Sea
+
+## Phase 1 to 3
+BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
+  y = Inside_CA3_DAS$VPUE_win,
+  sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
+  sigma.y = sd(Inside_CA3_DAS$VPUE_win),
+  alternative = c("two.sided"),
+  conf.level = 0.99)
+
+
 
 
 

--- a/analysis_code/case_study_comparisons.Rmd
+++ b/analysis_code/case_study_comparisons.Rmd
@@ -373,23 +373,7 @@ dropped_values_CA_1_3_GC %>%
 
 The first command tests the equality Winsorized Dollars for the Trips that were dropped during the CA 1 to CA 3 process (Call area to Lease Area)  against the trips that remained inside at the CA3 step (Lease Areas).  These are done at the 90, 95, and 99\% confidence levels.  Other commands are defined analgously.
 
-```{r}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
-  y = Inside_CA3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
-  y = Inside_CA3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
+```{r, CA1_to_3GC_Dollar_tests}
 
 BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
   y = Inside_CA3_GC$DOLLAR_2022_win,
@@ -406,57 +390,7 @@ BSDA::z.test(dropped_values_CA_1_3_GC$DOLLAR_2022_win,
 Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
-
-# Access Area 
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$DOLLAR_2022_win,
-  y = Inside_CA2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
+```{r, CA1_to_3AA_Dollar_tests}
 
 ## Phase 1 to 3
 
@@ -465,92 +399,10 @@ BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_CA_1_3_AA$DOLLAR_2022_win),
   sigma.y = sd(Inside_CA3_AA$DOLLAR_2022_win),
   alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
-  y = Inside_CA3_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_3_AA$DOLLAR_2022_win,
-  y = Inside_CA3_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
   conf.level = 0.99)
 
-# Days-at-Sea
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
 
 ## Phase 1 to 3
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA3_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
-  y = Inside_CA3_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
   y = Inside_CA3_DAS$DOLLAR_2022_win,
@@ -565,21 +417,8 @@ BSDA::z.test(dropped_values_CA_1_3_DAS$DOLLAR_2022_win,
 
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
-```{r}
+```{r, CA1_to_3GC_Landed_tests}
 
-BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
-  y = Inside_CA3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
-  sigma.y = sd(Inside_CA3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
-  y = Inside_CA3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$LANDED_win),
-  sigma.y = sd(Inside_CA3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
 
 BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
   y = Inside_CA3_GC$LANDED_win,
@@ -597,74 +436,9 @@ BSDA::z.test(dropped_values_CA_1_3_GC$LANDED_win,
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
-
-# Access Area 
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$LANDED_win,
-  y = Inside_CA2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
+```{r, CA1_to_3AA_Landed_tests}
 
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
-  y = Inside_CA3_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA3_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
-  y = Inside_CA3_AA$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$LANDED_win),
-  sigma.y = sd(Inside_CA3_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
   y = Inside_CA3_AA$LANDED_win,
@@ -676,72 +450,7 @@ BSDA::z.test(dropped_values_CA_1_3_AA$LANDED_win,
 
 
 # Days-at-Sea
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$LANDED_win,
-  y = Inside_CA2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
-  y = Inside_CA3_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
-  y = Inside_CA3_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_CA3_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
   y = Inside_CA3_DAS$LANDED_win,
@@ -760,21 +469,7 @@ BSDA::z.test(dropped_values_CA_1_3_DAS$LANDED_win,
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
-BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
+```{r, CA1_to_3GC_OperatingProfit_tests}
 
 BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
   y = Inside_CA3_GC$OPERATING_PROFIT_2022_win,
@@ -789,74 +484,10 @@ BSDA::z.test(dropped_values_CA_1_3_GC$OPERATING_PROFIT_2022_win,
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
+```{r, CA1_to_3AA_OperatingProfit_tests}
 
 # Access Area 
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
   y = Inside_CA3_AA$OPERATING_PROFIT_2022_win,
@@ -868,72 +499,8 @@ BSDA::z.test(dropped_values_CA_1_3_AA$OPERATING_PROFIT_2022_win,
 
 
 # Days-at-Sea
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
 
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_CA3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
   y = Inside_CA3_DAS$OPERATING_PROFIT_2022_win,
@@ -953,23 +520,7 @@ BSDA::z.test(dropped_values_CA_1_3_DAS$OPERATING_PROFIT_2022_win,
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 8. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
-
-BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
-  y = Inside_CA3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
-  sigma.y = sd(Inside_CA3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
-  y = Inside_CA3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_GC$VPUE_win),
-  sigma.y = sd(Inside_CA3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
+```{r, CA1_to_3GC_VPUE_tests}
 
 BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
   y = Inside_CA3_GC$VPUE_win,
@@ -985,75 +536,10 @@ BSDA::z.test(dropped_values_CA_1_3_GC$VPUE_win,
  Section 4.2 The Adaptive Wind Development Processes -  Central Atlantic - Code chunk below creates output for Table 9. Limited Access (AA) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.; Table 10. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the Central Atlantic region.
 
 
-```{r}
+```{r, CA1_to_3AA_VPUE_tests}
 
 # Access Area 
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_AA$VPUE_win,
-  y = Inside_CA2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
-  y = Inside_CA3_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
-  y = Inside_CA3_AA$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
-  sigma.y = sd(Inside_CA3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
   y = Inside_CA3_AA$VPUE_win,
   sigma.x = sd(dropped_values_CA_1_3_AA$VPUE_win),
@@ -1065,73 +551,8 @@ BSDA::z.test(dropped_values_CA_1_3_AA$VPUE_win,
 
 
 # Days-at-Sea
-## Phase 1 to 2
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_1_2_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_2_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
-
-
-## Phase 2 to 3
-BSDA::z.test(dropped_values_CA_2_3_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_CA_2_3_DAS$VPUE_win,
-  y = Inside_CA2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_2_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.99)
 
 ## Phase 1 to 3
-BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
-  y = Inside_CA3_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA3_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
-  y = Inside_CA3_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_CA3_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_CA_1_3_DAS$VPUE_win,
   y = Inside_CA3_DAS$VPUE_win,
   sigma.x = sd(dropped_values_CA_1_3_DAS$VPUE_win),
@@ -1294,24 +715,8 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
 
-```{r}
+```{r, NY_GC_Revenue_tests}
 ## Phase 1
-
-BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
-  y = Inside_NY2_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
-  y = Inside_NY2_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
   y = Inside_NY2_GC$DOLLAR_2022_win,
@@ -1321,22 +726,6 @@ BSDA::z.test(dropped_values_NY_1_2_GC$DOLLAR_2022_win,
   conf.level = 0.99)
 
 ## Phase 2
-
-BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
-  y = Inside_NY3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
-  y = Inside_NY3_GC$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY3_GC$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
   y = Inside_NY3_GC$DOLLAR_2022_win,
@@ -1355,27 +744,10 @@ BSDA::z.test(dropped_values_NY_2_3_GC$DOLLAR_2022_win,
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
 
 
-```{r}
+```{r, NY_LA_Revenue_tests}
 
 # Access Area 
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
   y = Inside_NY2_AA$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_AA$DOLLAR_2022_win),
@@ -1385,23 +757,7 @@ BSDA::z.test(dropped_values_NY_1_2_AA$DOLLAR_2022_win,
 
 ## Phase 2 to 3
 BSDA::z.test(dropped_values_NY_2_3_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$DOLLAR_2022_win,
-  y = Inside_NY2_AA$DOLLAR_2022_win,
+  y = Inside_NY3_AA$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_NY_2_3_AA$DOLLAR_2022_win),
   sigma.y = sd(Inside_NY2_AA$DOLLAR_2022_win),
   alternative = c("two.sided"),
@@ -1416,52 +772,16 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$DOLLAR_2022_win),
   sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
   alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$DOLLAR_2022_win,
-  y = Inside_NY2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$DOLLAR_2022_win,
-  y = Inside_NY2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
   conf.level = 0.99)
 
 
 ## Phase 2 to 3
-
 BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_NY2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_NY2_DAS$DOLLAR_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$DOLLAR_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
-  y = Inside_NY2_DAS$DOLLAR_2022_win,
+  y = Inside_NY3_DAS$DOLLAR_2022_win,
   sigma.x = sd(dropped_values_NY_2_3_DAS$DOLLAR_2022_win),
   sigma.y = sd(Inside_NY2_DAS$DOLLAR_2022_win),
   alternative = c("two.sided"),
   conf.level = 0.99)
-
-
-
 ```
 
 
@@ -1472,21 +792,8 @@ BSDA::z.test(dropped_values_NY_2_3_DAS$DOLLAR_2022_win,
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
 
 
-```{r}
+```{r, NY_GC_Landed_tests}
 ## Phase 1
-BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
-  y = Inside_NY2_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$LANDED_win),
-  sigma.y = sd(Inside_NY2_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
-  y = Inside_NY2_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$LANDED_win),
-  sigma.y = sd(Inside_NY2_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
 
 BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
   y = Inside_NY2_GC$LANDED_win,
@@ -1497,21 +804,6 @@ BSDA::z.test(dropped_values_NY_1_2_GC$LANDED_win,
 
 
 ## Phase 2
-
-BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
-  y = Inside_NY3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$LANDED_win),
-  sigma.y = sd(Inside_NY3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
-  y = Inside_NY3_GC$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$LANDED_win),
-  sigma.y = sd(Inside_NY3_GC$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
   y = Inside_NY3_GC$LANDED_win,
   sigma.x = sd(dropped_values_NY_2_3_GC$LANDED_win),
@@ -1529,27 +821,10 @@ BSDA::z.test(dropped_values_NY_2_3_GC$LANDED_win,
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
 
 
-```{r}
+```{r, NY_LA_Landed_tests}
 
 # Access Area 
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
   y = Inside_NY2_AA$LANDED_win,
   sigma.x = sd(dropped_values_NY_1_2_AA$LANDED_win),
@@ -1559,23 +834,7 @@ BSDA::z.test(dropped_values_NY_1_2_AA$LANDED_win,
 
 ## Phase 2 to 3
 BSDA::z.test(dropped_values_NY_2_3_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$LANDED_win),
-  sigma.y = sd(Inside_NY2_AA$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$LANDED_win,
-  y = Inside_NY2_AA$LANDED_win,
+  y = Inside_NY3_AA$LANDED_win,
   sigma.x = sd(dropped_values_NY_2_3_AA$LANDED_win),
   sigma.y = sd(Inside_NY2_AA$LANDED_win),
   alternative = c("two.sided"),
@@ -1590,44 +849,14 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$LANDED_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$LANDED_win),
   sigma.y = sd(Inside_NY2_DAS$LANDED_win),
   alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$LANDED_win,
-  y = Inside_NY2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$LANDED_win),
-  sigma.y = sd(Inside_NY2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$LANDED_win,
-  y = Inside_NY2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$LANDED_win),
-  sigma.y = sd(Inside_NY2_DAS$LANDED_win),
-  alternative = c("two.sided"),
   conf.level = 0.99)
 
 
 ## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_DAS$LANDED_win,
-  y = Inside_NY2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_NY2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
 
 
 BSDA::z.test(dropped_values_NY_2_3_DAS$LANDED_win,
-  y = Inside_NY2_DAS$LANDED_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$LANDED_win),
-  sigma.y = sd(Inside_NY2_DAS$LANDED_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$LANDED_win,
-  y = Inside_NY2_DAS$LANDED_win,
+  y = Inside_NY3_DAS$LANDED_win,
   sigma.x = sd(dropped_values_NY_2_3_DAS$LANDED_win),
   sigma.y = sd(Inside_NY2_DAS$LANDED_win),
   alternative = c("two.sided"),
@@ -1648,22 +877,8 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 
 
 
-```{r}
+```{r, NY_GC_Operating_profit_tests}
 # Phase 1 to 2 
-BSDA::z.test(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_NY_1_2_GC$OPERATING_PROFIT_2022_win,
   y = Inside_NY2_GC$OPERATING_PROFIT_2022_win,
@@ -1680,21 +895,6 @@ BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win),
   sigma.y = sd(Inside_NY3_GC$OPERATING_PROFIT_2022_win),
   alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
-  y = Inside_NY3_GC$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_GC$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
   conf.level = 0.99)
 ```
 
@@ -1702,27 +902,10 @@ BSDA::z.test(dropped_values_NY_2_3_GC$OPERATING_PROFIT_2022_win,
 
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 5. GC-IFQ Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for the New York Bight region.
 
-```{r}
+```{r, NY_LA_Operating_profit_tests}
 
 # Access Area 
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
   y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win),
@@ -1731,22 +914,6 @@ BSDA::z.test(dropped_values_NY_1_2_AA$OPERATING_PROFIT_2022_win,
   conf.level = 0.99)
 
 ## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_AA$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_AA$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
   y = Inside_NY3_AA$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win),
@@ -1757,23 +924,6 @@ BSDA::z.test(dropped_values_NY_2_3_AA$OPERATING_PROFIT_2022_win,
 
 # Days-at-Sea
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY2_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
   y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win),
@@ -1784,23 +934,7 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$OPERATING_PROFIT_2022_win,
 
 ## Phase 2 to 3
 BSDA::z.test(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win),
-  sigma.y = sd(Inside_NY3_DAS$OPERATING_PROFIT_2022_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win,
-  y = Inside_NY2_DAS$OPERATING_PROFIT_2022_win,
+  y = Inside_NY3_DAS$OPERATING_PROFIT_2022_win,
   sigma.x = sd(dropped_values_NY_2_3_DAS$OPERATING_PROFIT_2022_win),
   sigma.y = sd(Inside_NY3_DAS$OPERATING_PROFIT_2022_win),
   alternative = c("two.sided"),
@@ -1820,23 +954,8 @@ Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chu
 
 
 
-```{r}
+```{r, NY_GC_VPUE_tests}
 # Phase 1 to 2 
-BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
-  y = Inside_NY2_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$VPUE_win),
-  sigma.y = sd(Inside_NY2_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
-  y = Inside_NY2_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_GC$VPUE_win),
-  sigma.y = sd(Inside_NY2_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
   y = Inside_NY2_GC$VPUE_win,
   sigma.x = sd(dropped_values_NY_1_2_GC$VPUE_win),
@@ -1846,22 +965,6 @@ BSDA::z.test(dropped_values_NY_1_2_GC$VPUE_win,
 
 
 # Phase 2 to 3 
-
-BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
-  y = Inside_NY3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$VPUE_win),
-  sigma.y = sd(Inside_NY3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
-  y = Inside_NY3_GC$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_GC$VPUE_win),
-  sigma.y = sd(Inside_NY3_GC$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
   y = Inside_NY3_GC$VPUE_win,
   sigma.x = sd(dropped_values_NY_2_3_GC$VPUE_win),
@@ -1877,25 +980,9 @@ BSDA::z.test(dropped_values_NY_2_3_GC$VPUE_win,
 Section 4.2 The Adaptive Wind Development Processes -  New York Bight - Code chunk below creates output for Table 6. Limited Access (DAS) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.; Table 7. Limited Access (Access Area) Scallop trips, average scallop revenue, average landings, average operating profit, and average revenue per day for New York Bight.
 
 
-```{r}
+```{r, NY_LA_VPUE_tests}
 # LA 
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_LA$VPUE_win,
-  y = Inside_NY2_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_LA$VPUE_win),
-  sigma.y = sd(Inside_NY2_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_LA$VPUE_win,
-  y = Inside_NY2_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_LA$VPUE_win),
-  sigma.y = sd(Inside_NY2_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
 
 BSDA::z.test(dropped_values_NY_1_2_LA$VPUE_win,
   y = Inside_NY2_LA$VPUE_win,
@@ -1905,22 +992,6 @@ BSDA::z.test(dropped_values_NY_1_2_LA$VPUE_win,
   conf.level = 0.99)
 
 ## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_LA$VPUE_win,
-  y = Inside_NY2_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_LA$VPUE_win),
-  sigma.y = sd(Inside_NY3_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_LA$VPUE_win,
-  y = Inside_NY2_LA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_LA$VPUE_win),
-  sigma.y = sd(Inside_NY3_LA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_2_3_LA$VPUE_win,
   y = Inside_NY3_LA$VPUE_win,
   sigma.x = sd(dropped_values_NY_2_3_LA$VPUE_win),
@@ -1932,23 +1003,6 @@ BSDA::z.test(dropped_values_NY_2_3_LA$VPUE_win,
 
 # Access Area 
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
-  y = Inside_NY2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_NY2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
-  y = Inside_NY2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_AA$VPUE_win),
-  sigma.y = sd(Inside_NY2_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
   y = Inside_NY2_AA$VPUE_win,
   sigma.x = sd(dropped_values_NY_1_2_AA$VPUE_win),
@@ -1957,22 +1011,6 @@ BSDA::z.test(dropped_values_NY_1_2_AA$VPUE_win,
   conf.level = 0.99)
 
 ## Phase 2 to 3
-BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
-  y = Inside_NY2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_NY3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
-  y = Inside_NY2_AA$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_AA$VPUE_win),
-  sigma.y = sd(Inside_NY3_AA$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
   y = Inside_NY3_AA$VPUE_win,
   sigma.x = sd(dropped_values_NY_2_3_AA$VPUE_win),
@@ -1983,23 +1021,6 @@ BSDA::z.test(dropped_values_NY_2_3_AA$VPUE_win,
 
 # Days-at-Sea
 ## Phase 1 to 2
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
-  y = Inside_NY2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$VPUE_win),
-  sigma.y = sd(Inside_NY2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
-  y = Inside_NY2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_NY_1_2_DAS$VPUE_win),
-  sigma.y = sd(Inside_NY2_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
 BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
   y = Inside_NY2_DAS$VPUE_win,
   sigma.x = sd(dropped_values_NY_1_2_DAS$VPUE_win),
@@ -2010,23 +1031,7 @@ BSDA::z.test(dropped_values_NY_1_2_DAS$VPUE_win,
 
 ## Phase 2 to 3
 BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
-  y = Inside_NY2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_NY3_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.90)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
-  y = Inside_NY2_DAS$VPUE_win,
-  sigma.x = sd(dropped_values_NY_2_3_DAS$VPUE_win),
-  sigma.y = sd(Inside_NY3_DAS$VPUE_win),
-  alternative = c("two.sided"),
-  conf.level = 0.95)
-
-
-BSDA::z.test(dropped_values_NY_2_3_DAS$VPUE_win,
-  y = Inside_NY2_DAS$VPUE_win,
+  y = Inside_NY3_DAS$VPUE_win,
   sigma.x = sd(dropped_values_NY_2_3_DAS$VPUE_win),
   sigma.y = sd(Inside_NY3_DAS$VPUE_win),
   alternative = c("two.sided"),


### PR DESCRIPTION
@Ardini-NOAA 
1.  major error was in lines 176 to 183 of case_study_comparisons.    We were reading in the CA data as NY data. This has been fixed with 2fb379d2f263081d1bc799033c05ca72dcb9f9bc

2.  Removed the extra z-tests (we only need to do 1 test, the ``conf.level`` option is only used for the confidence interval construction and we don't use that.

4. Reordered the code to make it easier to cross-ref with the tables.  

I think the best way to test this is to just 
1. stash, commit or discard any chanages
2. Pull this branch
3. knit the case_study_comparisions.R file.

As long as it runs, please approve. If numbers don't match, we'll continue to troubleshoot.